### PR TITLE
Allow empty translates

### DIFF
--- a/engine/Library/Enlight/Components/Snippet/Namespace.php
+++ b/engine/Library/Enlight/Components/Snippet/Namespace.php
@@ -90,7 +90,7 @@ class Enlight_Components_Snippet_Namespace extends Enlight_Config
         if (array_key_exists($name, $this->_data)) {
             return $this->_data[$name];
         }
-        if ($default == null && $this->fallback) {
+        if ($default === null && $this->fallback) {
             $default = $this->fallback->get($name);
         }
         if ($save) {


### PR DESCRIPTION
### 1. Why is this change necessary?
To allow an empty string as fallback translation

### 2. What does this change do, exactly?
Check if the default is not set (null) or an empty string

### 3. Describe each step to reproduce the issue or behaviour.
$namespace->get('my_snippet', '', true);

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
None

### 6. Checklist

- [-] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [-] This change has comments for package types, values, functions, and non-obvious lines of code
- [-] I have read the contribution requirements and fulfil them.